### PR TITLE
fix: get balance and amount

### DIFF
--- a/src/components/transactions-and-payments-table.tsx
+++ b/src/components/transactions-and-payments-table.tsx
@@ -110,7 +110,7 @@ export function TransactionsAndPaymentsTable({
                     item?.dataObject?.data?.parameters?.currency?.value,
                   )
                 : getAmountWithCurrencySymbol(
-                    BigInt(item?.amountInCrypto || '0'),
+                    BigInt(item?.amountInCrypto || item?.amount || '0'),
                     item?.tokenAddress,
                   )}
             </TableCell>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -171,7 +171,7 @@ export const getPaymentDataFromCreateTransaction = (
 export const getBalance = (payments: Payment[] | undefined) => {
   return payments
     ? payments
-        .map((payment) => BigInt(payment?.amountInCrypto || '0'))
+        .map((payment) => BigInt(payment?.amount || payment?.amountInCrypto || '0'))
         .reduce((a, b) => a + b, BigInt(0))
     : BigInt(0);
 };


### PR DESCRIPTION
There was an issue on Paid status reported on Discord: https://discord.com/channels/468974345222619136/1312949192804794388

Add check for both `amount and amountInCrypto`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the "Amount" column in the Transactions and Payments Table to utilize an alternative amount source if `amountInCrypto` is unavailable.
	- Introduced a new utility function to capitalize the first letter of a string.

- **Bug Fixes**
	- Improved the balance calculation logic to ensure accurate retrieval of payment amounts.

- **Documentation**
	- Updated comments to reflect changes made to the `getBalance` function and the new `capitalize` utility function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->