### PR TITLE
fix: husky pre-commit warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
# Problem

Committing throws this warning:

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

# Solution

* Remove deprecated lines from `.husky/pre-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the pre-commit validation process to enhance code quality checks before commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->