### PR TITLE
Fix Dashboard Stat "Monthly Payments 30,000+" should say "Monthly Pay…

### DIFF
--- a/src/components/stats-area.tsx
+++ b/src/components/stats-area.tsx
@@ -36,7 +36,7 @@ export function StatsArea() {
           <Activity className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">30,000+</div>
+          <div className="text-2xl font-bold">10,000+</div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
Fixes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Monthly Payments figure displayed in the Stats area from "30,000+" to "10,000+". All other labels, icons, and layout remain unchanged. This is a presentational text update only; no behavior, performance, or interactions were modified elsewhere in the app. Users will simply see the new value in the same position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->