### PR TITLE
Rename xdai to gnosis, mainnet to ethereum (where possible).

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -19,61 +19,57 @@ import {
 } from "viem/chains";
 
 export const CHAINS = {
-  MAINNET: "mainnet",
   ARBITRUM_ONE: "arbitrum_one",
   AVALANCHE: "avalanche",
   BASE: "base",
   BSC: "bsc",
   CELO: "celo",
+  ETHEREUM: "mainnet",
   FANTOM: "fantom",
   FUSE: "fuse",
   MATIC: "matic",
   MOONBEAM: "moonbeam",
   OPTIMISM: "optimism",
   SEPOLIA: "sepolia",
-  XDAI: "xdai",
+  GNOSIS: "gnosis",
   ZKSYNCERA: "zksyncera",
 };
 
 export const CHAIN_SCAN_URLS = {
-  [CHAINS.MAINNET]: "https://etherscan.io",
   [CHAINS.ARBITRUM_ONE]: "https://arbiscan.io",
   [CHAINS.AVALANCHE]: "https://cchain.explorer.avax.network",
   [CHAINS.BASE]: "https://basescan.org",
   [CHAINS.BSC]: "https://bscscan.com",
   [CHAINS.CELO]: "https://explorer.celo.org",
+  [CHAINS.ETHEREUM]: "https://etherscan.io",
   [CHAINS.FANTOM]: "https://ftmscan.com",
   [CHAINS.FUSE]: "https://explorer.fuse.io",
   [CHAINS.MATIC]: "https://explorer-mainnet.maticvigil.com",
   [CHAINS.MOONBEAM]: "https://moonbeam-explorer.netlify.app",
   [CHAINS.OPTIMISM]: "https://optimistic.etherscan.io",
   [CHAINS.SEPOLIA]: "https://sepolia.etherscan.io",
-  [CHAINS.XDAI]: "https://gnosisscan.io",
+  [CHAINS.GNOSIS]: "https://gnosisscan.io",
   [CHAINS.ZKSYNCERA]: "https://explorer.zksync.io",
 };
 
 export enum PAYMENT_CHAINS {
-  MAINNET = "payment_mainnet",
   ARBITRUM_ONE = "payment_arbitrum_one",
   AVALANCHE = "payment_avalanche",
   BASE = "payment_base",
   BSC = "payment_bsc",
   CELO = "payment_celo",
+  ETHEREUM = "payment_ethereum",
   FANTOM = "payment_fantom",
   FUSE = "payment_fuse",
   MATIC = "payment_matic",
   MOONBEAM = "payment_moonbeam",
   OPTIMISM = "payment_optimism",
   SEPOLIA = "payment_sepolia",
-  XDAI = "payment_xdai",
+  GNOSIS = "payment_gnosis",
   ZKSYNCERA = "payment_zksyncera",
 }
 
 export const PUBLIC_CLIENTS = {
-  [CHAINS.MAINNET]: createPublicClient({
-    chain: mainnet,
-    transport: http(),
-  }),
   [CHAINS.ARBITRUM_ONE]: createPublicClient({
     chain: arbitrum,
     transport: http(),
@@ -92,6 +88,10 @@ export const PUBLIC_CLIENTS = {
   }),
   [CHAINS.CELO]: createPublicClient({
     chain: celo,
+    transport: http(),
+  }),
+  [CHAINS.ETHEREUM]: createPublicClient({
+    chain: mainnet,
     transport: http(),
   }),
   [CHAINS.FANTOM]: createPublicClient({
@@ -118,7 +118,7 @@ export const PUBLIC_CLIENTS = {
     chain: sepolia,
     transport: http(),
   }),
-  [CHAINS.XDAI]: createPublicClient({
+  [CHAINS.GNOSIS]: createPublicClient({
     chain: gnosis,
     transport: http(),
   }),

--- a/src/lib/hooks/payments.ts
+++ b/src/lib/hooks/payments.ts
@@ -10,16 +10,6 @@ export const PAYMENTS_QUERY = gql`
   ${CORE_PAYMENT_FIELDS}
   query PaymentsQuery($first: Int, $skip: Int!) {
     #
-    payment_mainnet {
-      payments(
-        first: $first
-        skip: $skip
-        orderBy: timestamp
-        orderDirection: desc
-      ) {
-        ...PaymentFields
-      }
-    }
     payment_arbitrum_one {
       payments(
         first: $first
@@ -61,6 +51,16 @@ export const PAYMENTS_QUERY = gql`
       }
     }
     payment_celo {
+      payments(
+        first: $first
+        skip: $skip
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
+        ...PaymentFields
+      }
+    }
+    payment_ethereum {
       payments(
         first: $first
         skip: $skip
@@ -130,7 +130,7 @@ export const PAYMENTS_QUERY = gql`
         ...PaymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       payments(
         first: $first
         skip: $skip

--- a/src/lib/queries/address-payments.ts
+++ b/src/lib/queries/address-payments.ts
@@ -9,17 +9,6 @@ import { CORE_PAYMENT_FIELDS } from "./utils";
 export const ADDRESS_PAYMENTS_QUERY = gql`
   ${CORE_PAYMENT_FIELDS}
   query AddressPaymentsQuery($first: Int, $skip: Int!, $address: Bytes) {
-    payment_mainnet {
-      payments(
-        first: $first
-        skip: $skip
-        orderBy: timestamp
-        orderDirection: desc
-        where: { or: [{ to: $address }, { from: $address }] }
-      ) {
-        ...PaymentFields
-      }
-    }
     payment_arbitrum_one {
       payments(
         first: $first
@@ -65,6 +54,17 @@ export const ADDRESS_PAYMENTS_QUERY = gql`
       }
     }
     payment_celo {
+      payments(
+        first: $first
+        skip: $skip
+        orderBy: timestamp
+        orderDirection: desc
+        where: { or: [{ to: $address }, { from: $address }] }
+      ) {
+        ...PaymentFields
+      }
+    }
+    payment_ethereum {
       payments(
         first: $first
         skip: $skip
@@ -141,7 +141,7 @@ export const ADDRESS_PAYMENTS_QUERY = gql`
         ...PaymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       payments(
         first: $first
         skip: $skip

--- a/src/lib/queries/payments.ts
+++ b/src/lib/queries/payments.ts
@@ -10,16 +10,6 @@ export const PAYMENTS_QUERY = gql`
   ${CORE_PAYMENT_FIELDS}
   query PaymentsQuery($first: Int, $skip: Int!) {
     #
-    payment_mainnet {
-      payments(
-        first: $first
-        skip: $skip
-        orderBy: timestamp
-        orderDirection: desc
-      ) {
-        ...PaymentFields
-      }
-    }
     payment_arbitrum_one {
       payments(
         first: $first
@@ -61,6 +51,16 @@ export const PAYMENTS_QUERY = gql`
       }
     }
     payment_celo {
+      payments(
+        first: $first
+        skip: $skip
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
+        ...PaymentFields
+      }
+    }
+    payment_ethereum {
       payments(
         first: $first
         skip: $skip
@@ -130,7 +130,7 @@ export const PAYMENTS_QUERY = gql`
         ...PaymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       payments(
         first: $first
         skip: $skip

--- a/src/lib/queries/request-payments.ts
+++ b/src/lib/queries/request-payments.ts
@@ -11,15 +11,6 @@ export const REQUEST_PAYMENTS_QUERY = gql`
 
   query RequestPaymentsQuery($reference: Bytes!) @cached {
     #
-    payment_mainnet {
-      payments(
-        orderBy: timestamp
-        orderDirection: desc
-        where: { reference: $reference }
-      ) {
-        ...PaymentFields
-      }
-    }
     payment_arbitrum_one {
       payments(
         where: { reference: $reference }
@@ -61,6 +52,15 @@ export const REQUEST_PAYMENTS_QUERY = gql`
         where: { reference: $reference }
         orderBy: timestamp
         orderDirection: desc
+      ) {
+        ...PaymentFields
+      }
+    }
+    payment_ethereum {
+      payments(
+        orderBy: timestamp
+        orderDirection: desc
+        where: { reference: $reference }
       ) {
         ...PaymentFields
       }
@@ -119,7 +119,7 @@ export const REQUEST_PAYMENTS_QUERY = gql`
         ...PaymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       payments(
         where: { reference: $reference }
         orderBy: timestamp

--- a/src/lib/queries/srf-deployments.ts
+++ b/src/lib/queries/srf-deployments.ts
@@ -7,16 +7,6 @@ import { CORE_PROXY_DEPLOYMENT_FIELDS } from "./utils";
 export const PROXY_DEPLOYMENTS_QUERY = gql`
   ${CORE_PROXY_DEPLOYMENT_FIELDS}
   query ProxyDeploymentsQuery($first: Int!, $skip: Int!) {
-    payment_mainnet {
-      singleRequestProxyDeployments(
-        first: $first
-        skip: $skip
-        orderBy: timestamp
-        orderDirection: desc
-      ) {
-        ...ProxyDeploymentFields
-      }
-    }
     payment_arbitrum_one {
       singleRequestProxyDeployments(
         first: $first
@@ -67,6 +57,16 @@ export const PROXY_DEPLOYMENTS_QUERY = gql`
         ...ProxyDeploymentFields
       }
     }
+    payment_ethereum {
+      singleRequestProxyDeployments(
+        first: $first
+        skip: $skip
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
+        ...ProxyDeploymentFields
+      }
+    }
     payment_matic {
       singleRequestProxyDeployments(
         first: $first
@@ -97,7 +97,7 @@ export const PROXY_DEPLOYMENTS_QUERY = gql`
         ...ProxyDeploymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       singleRequestProxyDeployments(
         first: $first
         skip: $skip
@@ -141,11 +141,6 @@ export const fetchProxyDeployments = async (variables: {
 export const PROXY_DEPLOYMENTS_BY_REFERENCE_QUERY = gql`
   ${CORE_PROXY_DEPLOYMENT_FIELDS}
   query ProxyDeploymentsByReferenceQuery($reference: Bytes!) {
-    payment_mainnet {
-      singleRequestProxyDeployments(where: { paymentReference: $reference }) {
-        ...ProxyDeploymentFields
-      }
-    }
     payment_arbitrum_one {
       singleRequestProxyDeployments(where: { paymentReference: $reference }) {
         ...ProxyDeploymentFields
@@ -171,6 +166,11 @@ export const PROXY_DEPLOYMENTS_BY_REFERENCE_QUERY = gql`
         ...ProxyDeploymentFields
       }
     }
+    payment_ethereum {
+      singleRequestProxyDeployments(where: { paymentReference: $reference }) {
+        ...ProxyDeploymentFields
+      }
+    }
     payment_matic {
       singleRequestProxyDeployments(where: { paymentReference: $reference }) {
         ...ProxyDeploymentFields
@@ -186,7 +186,7 @@ export const PROXY_DEPLOYMENTS_BY_REFERENCE_QUERY = gql`
         ...ProxyDeploymentFields
       }
     }
-    payment_xdai {
+    payment_gnosis {
       singleRequestProxyDeployments(where: { paymentReference: $reference }) {
         ...ProxyDeploymentFields
       }


### PR DESCRIPTION
Viem only supports gnosis and mainnet as chain name, 'ethereum' is not a supported chain name. Fixes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated blockchain network configurations to support current chain mappings.
  * Reorganized payment processing network references across data queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->