### PR TITLE
fix: stop every /request/<id> URL returning HTTP 500

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.0",
-        "@react-pdf/renderer": "^3.4.4",
         "@requestnetwork/currency": "^0.18.0",
         "@requestnetwork/data-format": "^0.19.0",
         "@requestnetwork/request-client.js": "^0.49.0",
@@ -2068,153 +2067,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
-    "node_modules/@react-pdf/fns": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-2.2.1.tgz",
-      "integrity": "sha512-s78aDg0vDYaijU5lLOCsUD+qinQbfOvcNeaoX9AiE7+kZzzCo6B/nX+l48cmt9OosJmvZvE9DWR9cLhrhOi2pA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13"
-      }
-    },
-    "node_modules/@react-pdf/font": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-2.5.1.tgz",
-      "integrity": "sha512-Hyb2zBb92Glc3lvhmJfy4dO2Mj29KB26Uk12Ua9EhKAdiuCTLBqgP8Oe1cGwrvDI7xA4OOcwvBMdYh0vhOUHzA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/types": "^2.5.0",
-        "cross-fetch": "^3.1.5",
-        "fontkit": "^2.0.2",
-        "is-url": "^1.2.4"
-      }
-    },
-    "node_modules/@react-pdf/image": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-2.3.6.tgz",
-      "integrity": "sha512-7iZDYZrZlJqNzS6huNl2XdMcLFUo68e6mOdzQeJ63d5eApdthhSHBnkGzHfLhH5t8DCpZNtClmklzuLL63ADfw==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/png-js": "^2.3.1",
-        "cross-fetch": "^3.1.5",
-        "jay-peg": "^1.0.2"
-      }
-    },
-    "node_modules/@react-pdf/layout": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-3.12.1.tgz",
-      "integrity": "sha512-BxSeykDxvADlpe4OGtQ7NH46QXq3uImAYsTHOPLCwbXMniQ1O3uCBx7H+HthxkCNshgYVPp9qS3KyvQv/oIZwg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "2.2.1",
-        "@react-pdf/image": "^2.3.6",
-        "@react-pdf/pdfkit": "^3.1.10",
-        "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/stylesheet": "^4.2.5",
-        "@react-pdf/textkit": "^4.4.1",
-        "@react-pdf/types": "^2.5.0",
-        "cross-fetch": "^3.1.5",
-        "emoji-regex": "^10.3.0",
-        "queue": "^6.0.1",
-        "yoga-layout": "^2.0.1"
-      }
-    },
-    "node_modules/@react-pdf/pdfkit": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-3.1.10.tgz",
-      "integrity": "sha512-P/qPBtCFo2HDJD0i6NfbmoBRrsOVO8CIogYsefwG4fklTo50zNgnMM5U1WLckTuX8Qt1ThiQuokmTG5arheblA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/png-js": "^2.3.1",
-        "browserify-zlib": "^0.2.0",
-        "crypto-js": "^4.2.0",
-        "fontkit": "^2.0.2",
-        "jay-peg": "^1.0.2",
-        "vite-compatible-readable-stream": "^3.6.1"
-      }
-    },
-    "node_modules/@react-pdf/png-js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-2.3.1.tgz",
-      "integrity": "sha512-pEZ18I4t1vAUS4lmhvXPmXYP4PHeblpWP/pAlMMRkEyP7tdAeHUN7taQl9sf9OPq7YITMY3lWpYpJU6t4CZgZg==",
-      "dependencies": {
-        "browserify-zlib": "^0.2.0"
-      }
-    },
-    "node_modules/@react-pdf/primitives": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-3.1.1.tgz",
-      "integrity": "sha512-miwjxLwTnO3IjoqkTVeTI+9CdyDggwekmSLhVCw+a/7FoQc+gF3J2dSKwsHvAcVFM0gvU8mzCeTofgw0zPDq0w=="
-    },
-    "node_modules/@react-pdf/render": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-3.4.4.tgz",
-      "integrity": "sha512-CfGxWmVgrY3JgmB1iMnz2W6Ck+8pisZeFt8vGlxP+JfT+0onr208pQvGSV5KwA9LGhAdABxqc/+y17V3vtKdFA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "2.2.1",
-        "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/textkit": "^4.4.1",
-        "@react-pdf/types": "^2.5.0",
-        "abs-svg-path": "^0.1.1",
-        "color-string": "^1.9.1",
-        "normalize-svg-path": "^1.1.0",
-        "parse-svg-path": "^0.1.2",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
-      }
-    },
-    "node_modules/@react-pdf/renderer": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-3.4.4.tgz",
-      "integrity": "sha512-j1TWMHHXDeHdoQE3xjhBh0MZ2rn7wHIlP/uglr/EJZXqnPbfg6bfLzRJCM6bs+XJV3d8+zLQjHf6sF/fWcBDfg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/font": "^2.5.1",
-        "@react-pdf/layout": "^3.12.1",
-        "@react-pdf/pdfkit": "^3.1.10",
-        "@react-pdf/primitives": "^3.1.1",
-        "@react-pdf/render": "^3.4.4",
-        "@react-pdf/types": "^2.5.0",
-        "events": "^3.3.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "queue": "^6.0.1",
-        "scheduler": "^0.17.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-pdf/stylesheet": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-4.2.5.tgz",
-      "integrity": "sha512-XnmapeCW+hDuNdVwpuvO04WKv71wAs8aH+saIq29Bo2fp1SxznHTcQArTZtK6Wgr/E9BHXeB2iAPpUZuI6G+xA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "2.2.1",
-        "@react-pdf/types": "^2.5.0",
-        "color-string": "^1.9.1",
-        "hsl-to-hex": "^1.0.0",
-        "media-engine": "^1.0.3",
-        "postcss-value-parser": "^4.1.0"
-      }
-    },
-    "node_modules/@react-pdf/textkit": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-4.4.1.tgz",
-      "integrity": "sha512-Jl9wdTqIvJ5pX+vAGz0EOhP7ut5Two9H6CzTKo/YYPeD79cM2yTXF3JzTERBC28y7LR0Waq9D2LHQjI+b/EYUQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@react-pdf/fns": "2.2.1",
-        "bidi-js": "^1.0.2",
-        "hyphen": "^1.6.4",
-        "unicode-properties": "^1.4.1"
-      }
-    },
-    "node_modules/@react-pdf/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-XsVRkt0hQ60I4e3leAVt+aZR3KJCaJd179BfJHAv4F4x6Vq3yqkry8lcbUWKGKDw1j3/8sW4FsgGR41SFvsG9A=="
-    },
     "node_modules/@requestnetwork/advanced-logic": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@requestnetwork/advanced-logic/-/advanced-logic-0.44.0.tgz",
@@ -2490,14 +2342,6 @@
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.54.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.54.1.tgz",
@@ -2770,11 +2614,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/abs-svg-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -3168,14 +3007,6 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -3226,28 +3057,12 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-      "dependencies": {
-        "base64-js": "^1.1.2"
-      }
-    },
     "node_modules/browserify-bignum": {
       "version": "1.3.0-2",
       "resolved": "https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz",
       "integrity": "sha512-PwVvKC3WIV7ENfsG6VAIDq4R5st6kQt+Fod3WL5l7+MRONClo3J6xGQvRJHHM/ScwcNCH3GfYX5UOCuoNN/rLw==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dependencies": {
-        "pako": "~1.0.5"
       }
     },
     "node_modules/btoa": {
@@ -3561,14 +3376,6 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3592,15 +3399,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3662,11 +3460,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-b64-images": {
       "version": "0.2.5",
@@ -3854,11 +3647,6 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
-    "node_modules/dfa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
-    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -3931,7 +3719,8 @@
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -4634,14 +4423,6 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -4779,22 +4560,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/fontkit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.12",
-        "brotli": "^1.3.2",
-        "clone": "^2.1.2",
-        "dfa": "^1.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "restructure": "^3.0.0",
-        "tiny-inflate": "^1.0.3",
-        "unicode-properties": "^1.4.0",
-        "unicode-trie": "^2.0.0"
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -5237,19 +5002,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hsl-to-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
-      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
-      "dependencies": {
-        "hsl-to-rgb-for-reals": "^1.1.0"
-      }
-    },
-    "node_modules/hsl-to-rgb-for-reals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
-      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="
-    },
     "node_modules/html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
@@ -5338,11 +5090,6 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
-    },
-    "node_modules/hyphen": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.4.tgz",
-      "integrity": "sha512-SejXzIpv9gOVdDWXd4suM1fdF1k2dxZGvuTdkOVLoazYfK7O4DykIQbdrvuyG+EaTNlXAGhMndtKrhykgbt0gg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5466,11 +5213,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/is-async-function": {
       "version": "2.0.0",
@@ -5813,11 +5555,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -5911,14 +5648,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jay-peg": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.0.2.tgz",
-      "integrity": "sha512-fyV3NVvv6pTys/3BTapBUGAWAuU9rM2gRcgijZHzptd5KKL+s+S7hESFN+wOsbDH1MzFwdlRAXi0aGxS6uiMKg==",
-      "dependencies": {
-        "restructure": "^3.0.0"
       }
     },
     "node_modules/jiti": {
@@ -6438,11 +6167,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
-    "node_modules/media-engine": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
-      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg=="
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -6750,14 +6474,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-svg-path": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
-      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
-      "dependencies": {
-        "svg-arc-to-cubic-bezier": "^3.0.0"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -6999,11 +6715,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -7024,11 +6735,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
@@ -7314,6 +7020,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7340,14 +7047,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "dependencies": {
-        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -7413,7 +7112,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.7",
@@ -7580,14 +7280,6 @@
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.61.0.tgz",
       "integrity": "sha512-caKfSz9rDeSKBQQnlJnVW3mbVdFgxgGWQKq1XlFokqjf+hQD5gxutLGTTY2A/x24UxVyJe9gH5fAkFI63ULw4A=="
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -7652,11 +7344,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/restructure": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -7804,15 +7491,6 @@
         "big.js": "^3.1.3"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
-      "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -7935,14 +7613,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8045,14 +7715,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -8385,11 +8047,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-arc-to-cubic-bezier": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
-    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -8538,11 +8195,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
       "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w=="
-    },
-    "node_modules/tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -8743,29 +8395,6 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
-    "node_modules/unicode-properties": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
-    "node_modules/unicode-trie/node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8877,19 +8506,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-compatible-readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
-      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/webauthn-p256": {
@@ -9163,11 +8779,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/yoga-layout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-2.0.1.tgz",
-      "integrity": "sha512-tT/oChyDXelLo2A+UVnlW9GU7CsvFMaEnd9kVFsaiCQonFAXd3xrHhkLYu+suwwosrAEQ746xBU+HvYtm1Zs2Q=="
     },
     "node_modules/zod": {
       "version": "3.23.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
-    "@react-pdf/renderer": "^3.4.4",
     "@requestnetwork/currency": "^0.18.0",
     "@requestnetwork/data-format": "^0.19.0",
     "@requestnetwork/request-client.js": "^0.49.0",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,52 @@
+/** @format */
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import Link from "next/link";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex pt-24 justify-center">
+      <Card className="flex-col justify-center items-center text-center h-[400px] w-[95%] md:h-[700px] pt-32 md:pt-52">
+        <CardHeader>
+          <CardTitle>Something went wrong</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CardDescription>
+            An unexpected error occurred while loading this page.
+            {error.digest && (
+              <span className="block mt-2 text-xs">
+                Reference: {error.digest}
+              </span>
+            )}
+          </CardDescription>
+        </CardContent>
+        <CardFooter className="flex justify-center gap-4">
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="font-medium text-emerald-700"
+          >
+            Try again
+          </button>
+          <div className="font-medium text-emerald-700">
+            <Link href="/">Back to home</Link>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,52 @@
+/** @format */
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <div className="flex pt-24 justify-center">
+          <Card className="flex-col justify-center items-center text-center h-[400px] w-[95%] md:h-[700px] pt-32 md:pt-52">
+            <CardHeader>
+              <CardTitle>Something went wrong</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <CardDescription>
+                A critical error occurred. Please reload the page.
+                {error.digest && (
+                  <span className="block mt-2 text-xs">
+                    Reference: {error.digest}
+                  </span>
+                )}
+              </CardDescription>
+            </CardContent>
+            <CardFooter className="flex justify-center">
+              <button
+                type="button"
+                onClick={() => reset()}
+                className="font-medium text-emerald-700"
+              >
+                Reload
+              </button>
+            </CardFooter>
+          </Card>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,33 @@
+/** @format */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex pt-24 justify-center">
+      <Card className="flex-col justify-center items-center text-center h-[400px] w-[95%] md:h-[700px] pt-32 md:pt-52">
+        <CardHeader>
+          <CardTitle>Page not found</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CardDescription>
+            The page you are looking for does not exist.
+          </CardDescription>
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          <div className="font-medium text-emerald-700">
+            <Link href="/">Back to home</Link>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/request/[id]/page.tsx
+++ b/src/app/request/[id]/page.tsx
@@ -35,7 +35,7 @@ import { useQuery } from "@tanstack/react-query";
 import { JsonEditor } from "json-edit-react";
 import { Copy, File, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { useState } from "react";
 import TimeAgo from "timeago-react";
 
@@ -138,7 +138,7 @@ export default function RequestPage({ params: { id } }: RequestPageProps) {
   const { exportPDF } = useExportPDF();
   const [isDownloading, setIsDownloading] = useState(false);
 
-  const { data: request, isLoading: isLoadingRequest } = useQuery({
+  const { data: request, status: requestStatus } = useQuery({
     queryKey: ["request", id],
     queryFn: () => fetchRequest({ id }),
     ...commonQueryOptions,
@@ -147,10 +147,10 @@ export default function RequestPage({ params: { id } }: RequestPageProps) {
   const shortPaymentReference = request
     ? calculateShortPaymentReference(
         id,
-        request?.transactions[0].dataObject?.data?.parameters?.extensionsData[0]
-          ?.parameters.salt || "",
-        request?.transactions[0].dataObject?.data?.parameters?.extensionsData[0]
-          ?.parameters.paymentAddress || "",
+        request?.transactions?.[0]?.dataObject?.data?.parameters
+          ?.extensionsData?.[0]?.parameters.salt || "",
+        request?.transactions?.[0]?.dataObject?.data?.parameters
+          ?.extensionsData?.[0]?.parameters.paymentAddress || "",
       )
     : "";
 
@@ -173,17 +173,21 @@ export default function RequestPage({ params: { id } }: RequestPageProps) {
     ...commonQueryOptions,
   });
 
-  if (isLoadingRequest || isLoadingRequestPayments || isLoadingSRF) {
+  if (requestStatus === "pending" || isLoadingRequestPayments || isLoadingSRF) {
     return <Skeleton className="h-[500px] w-full rounded-xl" />;
   }
 
-  if (!request) {
-    redirect("/not-found");
+  if (requestStatus === "error") {
+    return <div>Error occurred while fetching data.</div>;
   }
 
-  const firstTransaction = request?.transactions[0];
+  if (!request) {
+    notFound();
+  }
+
+  const firstTransaction = request?.transactions?.[0];
   const lastTransaction =
-    request?.transactions[request.transactions.length - 1];
+    request?.transactions?.[request.transactions.length - 1];
 
   const balance = getBalance(requestPayments);
 
@@ -354,10 +358,10 @@ export default function RequestPage({ params: { id } }: RequestPageProps) {
                   <td className="text-muted-foreground">Created:</td>
                   <td className="pl-16">
                     <TimeAgo
-                      datetime={firstTransaction.blockTimestamp * 1000}
+                      datetime={(firstTransaction?.blockTimestamp || 0) * 1000}
                       locale="en_short"
                     />{" "}
-                    ({formatTimestamp(firstTransaction.blockTimestamp)})
+                    ({formatTimestamp(firstTransaction?.blockTimestamp || 0)})
                   </td>
                 </tr>
                 <tr>

--- a/src/components/payment-table.tsx
+++ b/src/components/payment-table.tsx
@@ -109,13 +109,19 @@ export const columns: ColumnDef<Payment>[] = [
   {
     accessorKey: "networkFee",
     header: "Network Fee",
-    cell: ({ row }) =>
-      formatUnits(
-        BigInt(
-          Number(row?.original?.gasUsed) * Number(row?.original?.gasPrice),
-        ),
-        18,
-      ),
+    cell: ({ row }) => {
+      const { gasUsed, gasPrice } = row.original;
+
+      if (!gasUsed || !gasPrice) {
+        return "N/A";
+      }
+
+      try {
+        return formatUnits(BigInt(gasUsed) * BigInt(gasPrice), 18);
+      } catch {
+        return "N/A";
+      }
+    },
   },
   {
     accessorKey: "feeAmount",

--- a/src/components/recent-payment-table.tsx
+++ b/src/components/recent-payment-table.tsx
@@ -27,12 +27,16 @@ import TimeAgo from "timeago-react";
 import { Skeleton } from "./ui/skeleton";
 
 export function RecentPaymentTable() {
-  const { payments, isLoading } = useLatestPayments({
+  const { payments, isLoading, status } = useLatestPayments({
     pollInterval: Number(process.env.NEXT_PUBLIC_POLL_INTERVAL) || 30000,
   });
 
   if (isLoading) {
     return <Skeleton className="h-full w-full rounded-xl" />;
+  }
+
+  if (status === "error") {
+    return <div>Error occurred while fetching data.</div>;
   }
 
   if (!payments) {

--- a/src/components/recent-request-table.tsx
+++ b/src/components/recent-request-table.tsx
@@ -25,12 +25,16 @@ import TimeAgo from "timeago-react";
 import { Skeleton } from "./ui/skeleton";
 
 export function RecentRequestTable() {
-  const { requests, isLoading } = useLatestRequests({
+  const { requests, isLoading, status } = useLatestRequests({
     pollInterval: Number(process.env.NEXT_PUBLIC_POLL_INTERVAL) || 30000,
   });
 
   if (isLoading) {
     return <Skeleton className="h-svh w-full rounded-xl" />;
+  }
+
+  if (status === "error") {
+    return <div>Error occurred while fetching data.</div>;
   }
 
   if (!requests) {

--- a/src/components/recent-srf-deployments-table.tsx
+++ b/src/components/recent-srf-deployments-table.tsx
@@ -25,12 +25,16 @@ import TimeAgo from "timeago-react";
 import { Skeleton } from "./ui/skeleton";
 
 export function RecentSRFDeploymentsTable() {
-  const { deployments, isLoading } = useLatestSRFDeployments({
+  const { deployments, isLoading, status } = useLatestSRFDeployments({
     pollInterval: Number(process.env.NEXT_PUBLIC_POLL_INTERVAL) || 30000,
   });
 
   if (isLoading) {
     return <Skeleton className="h-svh w-full rounded-xl" />;
+  }
+
+  if (status === "error") {
+    return <div>Error occurred while fetching data.</div>;
   }
 
   if (!deployments) {

--- a/src/components/request-table.tsx
+++ b/src/components/request-table.tsx
@@ -51,10 +51,10 @@ export const columns: ColumnDef<Transaction>[] = [
     cell: ({ row }) => {
       return calculateShortPaymentReference(
         row.original.channelId,
-        row.original?.dataObject.data.parameters.extensionsData[0].parameters
-          .salt || "",
-        row.original?.dataObject.data.parameters.extensionsData[0].parameters
-          .paymentAddress || "",
+        row.original?.dataObject?.data?.parameters?.extensionsData?.[0]
+          ?.parameters?.salt || "",
+        row.original?.dataObject?.data?.parameters?.extensionsData?.[0]
+          ?.parameters?.paymentAddress || "",
       );
     },
   },

--- a/src/lib/hooks/use-export-pdf.tsx
+++ b/src/lib/hooks/use-export-pdf.tsx
@@ -2,8 +2,6 @@
 "use client";
 
 import type { Invoice, InvoiceItem } from "@requestnetwork/data-format";
-// @ts-expect-error: No html2pdf does not have the @types to install
-import html2pdf from "html2pdf.js";
 import { formatUnits, isAddress } from "viem";
 import { currencyManager } from "../currency-manager";
 import type { PaymentData } from "../types";
@@ -79,6 +77,9 @@ export default function useExportPDF() {
 
     const generatePDF = async () => {
       try {
+        // @ts-expect-error: html2pdf.js does not have the @types to install
+        const html2pdf = (await import("html2pdf.js")).default;
+
         const currencyDetails = getCurrencyDetails(invoice.currencyInfo?.value);
         const paymentCurrencyDetails = getCurrencyDetails(
           invoice.paymentData?.acceptedTokens?.length > 0


### PR DESCRIPTION
Every `/request/<id>` URL on scan.request.network returns **HTTP 500**. This fixes it. Bottom of a 3-PR stack; independently mergeable.

Came out of an SEO audit (Linear REQ-285) that listed 132 request URLs returning 5XX. It is not 132 broken pages — it is one bug, and the set is unbounded: a request created minutes ago 500s just the same.

## Root cause

`html2pdf.js` **0.10.2** — the version `package-lock.json` pins — invokes its UMD wrapper with a bare `self` identifier, evaluated before the inner `require()`s and with no `typeof self !== "undefined"` guard. Node has no global `self`, so *importing* it server-side throws. It was imported at module scope in `use-export-pdf.tsx`, whose only importer is `request/[id]/page.tsx` — which is exactly why that one route 500ed while every other returned 200.

Reproduced locally before the fix:

```
ReferenceError: self is not defined
    at 11378 (.next/server/app/request/[id]/page.js)
    at Object.t [as require] (.next/server/webpack-runtime.js)
```

The import now happens inside the export handler, so it only evaluates in a browser.

**Impact worth stating precisely:** Next.js bails out to client rendering after the SSR throw, so a real browser renders the page fine — users clicking through from the homepage were unaffected. Crawlers, shared links, hard refreshes and anything status-code-sensitive got a 500 with no content.

**Side benefit:** the route's page bundle drops **196 kB → 22.8 kB** and first-load JS **1.02 MB → 851 kB**, since html2pdf no longer ships eagerly.

## Why CI never caught this

`next build` compiles the route but never requests it — `page.tsx` has no `generateStaticParams`, so the build marks it `ƒ (Dynamic) server-rendered on demand`. `npm run check` is `biome check --write`, formatting only, and `--write` means it cannot fail on anything auto-fixable. There are no tests in the repo. PR #117 adds the request-time smoke check that would have caught it.

## Also in this PR

All found while tracing the above:

- **Error boundaries.** There were none — no `app/error.tsx`, no `global-error.tsx`, no root `not-found.tsx` (`app/not-found/page.tsx` is an ordinary route, not the convention file). Any render-time throw escaped to a raw 500. Added all three; neither leaks an error message or stack.
- **A missing request reported 200.** The page called `redirect("/not-found")` — a 307 to a page that itself returns 200, i.e. a soft 404 telling crawlers a nonexistent request exists. Now `notFound()`.
- **"Failed" was indistinguishable from "not found."** The page read only `isLoading`, never `error`, so a backend failure rendered as "not found". Now gates on the query's `status`: pending → skeleton, error → error state, success-and-empty → `notFound()`. `isLoading` was doubly wrong here — with react-query v5 it is `isPending && isFetching`, and no fetch happens during SSR, so it is **false** on the server and the skeleton guard never fired there.
- **Error states in the three "Recent …" widgets**, which ignored the `status` their hooks already return and rendered "No data" on failure. This is live today: the payments subgraph returns `no allocations`, so the home page currently reports empty rather than broken.
- **Two crashers guarded.** The fully-unguarded `extensionsData[0].parameters` path in `request-table.tsx` throws while evaluating arguments, and therefore *outside* the try/catch inside `calculateShortPaymentReference` — the likely cause of **#89**. And `BigInt(Number(gasUsed) * Number(gasPrice))` in `payment-table.tsx`, where a missing field makes `BigInt(NaN)` throw a `RangeError`; it now multiplies in BigInt, which also avoids losing precision above `Number.MAX_SAFE_INTEGER`.
- **Dropped `@react-pdf/renderer`**, imported nowhere. The lockfile is regenerated to match — worth noting because `npm ci` *fails* on a package.json/lockfile mismatch, so CI would have broken on its first job otherwise.

Likely also closes **#72** (an unindexed request showing as "404") now that error and not-found are distinct states.

## Verification

`npm ci` → `npm run check` → `npm run build`, then a real server:

| Route | Before | After |
|---|---|---|
| `/request/<id>` | **500** | **200** |
| `/`, `/requests`, `/payments` | 200 | 200 |
| unmatched route | — | 404 |
| `self is not defined` in log | present | **zero** |

## Known gap, fixed in #118

The page still fetches on the client, so the served HTML is a skeleton with no request data, and a nonexistent id returns 200 rather than 404. Both need a server-side fetch — that is #118.
