### PR TITLE
feat: server-render the request page so crawlers get the request

### DIFF
--- a/src/app/request/[id]/page.tsx
+++ b/src/app/request/[id]/page.tsx
@@ -1,43 +1,10 @@
 /** @format */
-"use client";
 
-import { SRFInfoSection } from "@/components/srf-info-section";
-import { TransactionsAndPaymentsTable } from "@/components/transactions-and-payments-table";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import useExportPDF from "@/lib/hooks/use-export-pdf";
 import { fetchRequest } from "@/lib/queries/channel";
-import { fetchRequestPayments } from "@/lib/queries/request-payments";
-import { fetchProxyDeploymentsByReference } from "@/lib/queries/srf-deployments";
-import type { Channel } from "@/lib/types";
-import {
-  calculateLongPaymentReference,
-  calculateShortPaymentReference,
-  capitalize,
-  commonQueryOptions,
-  formatTimestamp,
-  getAmountWithCurrencySymbol,
-  getBalance,
-  getContentDataFromCreateTransaction,
-  getPaymentDataFromCreateTransaction,
-  getTransactionCreateParameters,
-  renderAddress,
-} from "@/lib/utils";
-import type { ActorInfo } from "@requestnetwork/data-format";
-import { useQuery } from "@tanstack/react-query";
-import { JsonEditor } from "json-edit-react";
-import { Copy, File, Loader2 } from "lucide-react";
-import Link from "next/link";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { useState } from "react";
-import TimeAgo from "timeago-react";
+import { cache } from "react";
+import { RequestDetails } from "./request-details";
 
 interface RequestPageProps {
   params: {
@@ -45,402 +12,52 @@ interface RequestPageProps {
   };
 }
 
-const getGateway = (request: Channel | null) => {
-  if (request?.source === "storage_sepolia") {
-    return "sepolia.gateway.request.network";
+// Memoized per render pass so generateMetadata and the page share one network
+// call. The fetch-level cache cannot do this: graphql-request issues a POST,
+// which Next's Data Cache does not dedupe, and the cache() wrapper inside
+// graphQlClient is keyed on a fresh RequestInit object per call. Keying on the
+// id string here is what actually collapses the two reads into one.
+const getRequest = cache((id: string) => fetchRequest({ id }));
+
+// A missing request is marked noindex rather than returning a 404 status, and
+// that is a deliberate concession to a framework limit, not an oversight. This
+// route streams (Transfer-Encoding: chunked), so the HTTP status is committed
+// when the shell flushes, before the lookup resolves. notFound() therefore
+// swaps the rendered UI but cannot change the status — verified both from the
+// page body and from generateMetadata; both return 200. Until that can return a
+// real 404 (which needs the check to run before the response commits, i.e. in
+// middleware), noindex is what actually prevents these from polluting the
+// search index, which is the harm a soft 404 does.
+export const generateMetadata = async ({
+  params: { id },
+}: RequestPageProps): Promise<Metadata> => {
+  const request = await getRequest(id);
+
+  if (!request) {
+    return {
+      title: "Request not found | Request Scan",
+      robots: { index: false, follow: false },
+    };
   }
-  return "gnosis.gateway.request.network";
+
+  return {
+    title: `Request ${id} | Request Scan`,
+    description: `Details of request ${id} on the Request Network: status, payee, payer, expected amount, balance, payment reference, transactions and payments.`,
+  };
 };
 
-const ActorInfoSection = ({
-  actorInfo,
-  isEncrypted,
-}: { actorInfo?: ActorInfo; isEncrypted?: boolean }) => {
-  if (
-    !actorInfo ||
-    Object.keys(actorInfo).every(
-      (k) => !Object.keys((actorInfo as any)[k]).length,
-    )
-  ) {
-    return "N/A";
-  }
-
-  if (isEncrypted) {
-    return (
-      <div className="grid gap-3 bg-muted/50 rounded-md p-2 overflow-x-scroll">
-        <ul className="grid gap-3">
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Status:</span>
-            <span>Encrypted</span>
-          </li>
-        </ul>
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid gap-3 bg-muted/50 rounded-md p-2 overflow-x-scroll">
-      <ul className="grid gap-3">
-        {actorInfo?.businessName && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Business Name:</span>
-            <span>{actorInfo?.businessName}</span>
-          </li>
-        )}
-        {actorInfo?.firstName && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">First Name:</span>
-            <span>{actorInfo?.firstName}</span>
-          </li>
-        )}
-        {actorInfo?.lastName && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Last Name:</span>
-            <span>{actorInfo?.lastName}</span>
-          </li>
-        )}
-        {actorInfo?.email && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Email:</span>
-            <span>{actorInfo?.email}</span>
-          </li>
-        )}
-        {actorInfo?.phone && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Phone:</span>
-            <span>{actorInfo?.phone}</span>
-          </li>
-        )}
-        {actorInfo?.address && Object.keys(actorInfo?.address).length > 0 && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Address:</span>
-            <span>{renderAddress(actorInfo)}</span>
-          </li>
-        )}
-        {actorInfo?.taxRegistration && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Tax Registration:</span>
-            <span>{actorInfo?.taxRegistration}</span>
-          </li>
-        )}
-        {actorInfo?.miscellaneous! && (
-          <li className="flex items-center justify-start gap-2">
-            <span className="text-muted-foreground">Miscellaneous:</span>
-            <span>{JSON.stringify(actorInfo?.miscellaneous!)}</span>
-          </li>
-        )}
-      </ul>
-    </div>
-  );
-};
-
-export default function RequestPage({ params: { id } }: RequestPageProps) {
-  const { exportPDF } = useExportPDF();
-  const [isDownloading, setIsDownloading] = useState(false);
-
-  const { data: request, status: requestStatus } = useQuery({
-    queryKey: ["request", id],
-    queryFn: () => fetchRequest({ id }),
-    ...commonQueryOptions,
-  });
-
-  const shortPaymentReference = request
-    ? calculateShortPaymentReference(
-        id,
-        request?.transactions?.[0]?.dataObject?.data?.parameters
-          ?.extensionsData?.[0]?.parameters.salt || "",
-        request?.transactions?.[0]?.dataObject?.data?.parameters
-          ?.extensionsData?.[0]?.parameters.paymentAddress || "",
-      )
-    : "";
-
-  const longPaymentReference = shortPaymentReference
-    ? calculateLongPaymentReference(shortPaymentReference)
-    : "";
-
-  const { data: requestPayments, isLoading: isLoadingRequestPayments } =
-    useQuery({
-      queryKey: ["request-payments", longPaymentReference],
-      queryFn: () => fetchRequestPayments({ reference: longPaymentReference }),
-      ...commonQueryOptions,
-    });
-
-  const { data: srfDeployments, isLoading: isLoadingSRF } = useQuery({
-    queryKey: ["srf-deployments", longPaymentReference],
-    queryFn: () =>
-      fetchProxyDeploymentsByReference({ reference: longPaymentReference }),
-    enabled: !!longPaymentReference,
-    ...commonQueryOptions,
-  });
-
-  if (requestStatus === "pending" || isLoadingRequestPayments || isLoadingSRF) {
-    return <Skeleton className="h-[500px] w-full rounded-xl" />;
-  }
-
-  if (requestStatus === "error") {
-    return <div>Error occurred while fetching data.</div>;
-  }
+export default async function RequestPage({
+  params: { id },
+}: RequestPageProps) {
+  // Fetched on the server so crawlers and link previews receive the request in
+  // the initial HTML. A thrown fetch is intentionally left to propagate to the
+  // error boundary: a backend outage must not be reported as "this request does
+  // not exist".
+  const request = await getRequest(id);
 
   if (!request) {
     notFound();
   }
 
-  const firstTransaction = request?.transactions?.[0];
-  const lastTransaction =
-    request?.transactions?.[request.transactions.length - 1];
-
-  const balance = getBalance(requestPayments);
-
-  const createParametersFromFirstTransaction =
-    getTransactionCreateParameters(firstTransaction);
-  const createParametersFromLastTransaction =
-    getTransactionCreateParameters(lastTransaction);
-
-  const contentData = getContentDataFromCreateTransaction(
-    createParametersFromLastTransaction,
-  );
-  const paymentData = getPaymentDataFromCreateTransaction(
-    createParametersFromFirstTransaction,
-  );
-
-  const balanceCurrency =
-    paymentData?.acceptedTokens?.length > 0
-      ? paymentData.acceptedTokens[0]
-      : "";
-
-  const buyerData = contentData?.buyerInfo;
-  const sellerData = contentData?.sellerInfo;
-
-  const status =
-    balance >= BigInt(createParametersFromFirstTransaction?.expectedAmount || 0)
-      ? "Paid"
-      : lastTransaction?.dataObject?.data?.name;
-
-  const modifiedTimestamp =
-    requestPayments &&
-    requestPayments[requestPayments?.length - 1]?.timestamp >
-      lastTransaction?.blockTimestamp
-      ? requestPayments[requestPayments?.length - 1]?.timestamp
-      : lastTransaction?.blockTimestamp;
-
-  const handleExportPDF = async () => {
-    setIsDownloading(true);
-    try {
-      await exportPDF({
-        ...contentData,
-        currency: createParametersFromFirstTransaction?.currency,
-        currencyInfo: createParametersFromFirstTransaction?.currency,
-        payer: createParametersFromFirstTransaction?.payer,
-        payee: createParametersFromFirstTransaction?.payee,
-        expectedAmount: createParametersFromFirstTransaction?.expectedAmount,
-        paymentData,
-      });
-    } catch (error) {
-      console.error("Error exporting PDF:", error);
-    } finally {
-      setIsDownloading(false);
-    }
-  };
-
-  return (
-    <div className="h-full pt-24 pb-32">
-      <div className="w-[95%] bg-white border rounded-lg self-center md:w-full">
-        <Card className="overflow-hidden" x-chunk="dashboard-05-chunk-4">
-          <CardHeader className="flex flex-row items-start bg-muted/50">
-            <div className="grid gap-0.5 w-full">
-              <CardTitle className="group flex items-center gap-2 text-lg break-all w-full justify-between">
-                <div className="flex gap-2 items-center">
-                  Request {id}
-                  <Button
-                    size="icon"
-                    variant="outline"
-                    className="h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
-                    onClick={() => {
-                      navigator.clipboard.writeText(id);
-                    }}
-                  >
-                    <Copy className="h-3 w-3" />
-                  </Button>
-                </div>
-                <Button
-                  size="sm"
-                  className="h-8 gap-1"
-                  onClick={handleExportPDF}
-                  disabled={isDownloading}
-                >
-                  {isDownloading && (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  )}
-                  <File className="h-3.5 w-3.5" />
-                  <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-                    Export PDF
-                  </span>
-                </Button>
-              </CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="p-6 text-sm overflow-x-scroll">
-            <table className="border-separate border-spacing-y-3">
-              <tbody>
-                <tr>
-                  <td className="text-muted-foreground">Status:</td>
-                  <td className="pl-16">{status}</td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Gateway:</td>
-                  <td className="pl-16">{getGateway(request)}</td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Payee:</td>
-                  <td className="pl-16">
-                    <div className="font-medium text-emerald-700 break-all">
-                      <Link
-                        href={`/address/${createParametersFromFirstTransaction?.payee?.value}`}
-                      >
-                        {createParametersFromFirstTransaction?.payee?.value}
-                      </Link>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Payee Details:</td>
-                  <td className="pl-16">
-                    <ActorInfoSection
-                      actorInfo={sellerData}
-                      isEncrypted={!!firstTransaction?.encryptedData}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Payer:</td>
-                  <td className="pl-16">
-                    <div className="font-medium text-emerald-700 break-all">
-                      <Link
-                        href={`/address/${createParametersFromFirstTransaction?.payer?.value}`}
-                      >
-                        {createParametersFromFirstTransaction?.payer?.value}
-                      </Link>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Payer Details:</td>
-                  <td className="pl-16">
-                    <ActorInfoSection
-                      actorInfo={buyerData}
-                      isEncrypted={!!firstTransaction?.encryptedData}
-                    />
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Expected Amount:</td>
-                  <td className="pl-16">
-                    {getAmountWithCurrencySymbol(
-                      BigInt(
-                        createParametersFromFirstTransaction?.expectedAmount ||
-                          0,
-                      ),
-                      createParametersFromFirstTransaction?.currency?.value ||
-                        "",
-                    )}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Balance:</td>
-                  <td className="pl-16">
-                    {getAmountWithCurrencySymbol(
-                      BigInt(balance),
-                      balanceCurrency || "",
-                    )}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Created:</td>
-                  <td className="pl-16">
-                    <TimeAgo
-                      datetime={(firstTransaction?.blockTimestamp || 0) * 1000}
-                      locale="en_short"
-                    />{" "}
-                    ({formatTimestamp(firstTransaction?.blockTimestamp || 0)})
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Modified:</td>
-                  <td className="pl-16">
-                    <TimeAgo
-                      datetime={modifiedTimestamp * 1000}
-                      locale="en_short"
-                    />{" "}
-                    ({formatTimestamp(modifiedTimestamp)})
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Payment Reference:</td>
-                  <td className="pl-16">{shortPaymentReference}</td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Blockchain:</td>
-                  <td className="pl-16">
-                    {paymentData?.network
-                      ? capitalize(paymentData?.network)
-                      : ""}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Encryption Status:</td>
-                  <td className="pl-16">
-                    {firstTransaction?.encryptedData
-                      ? "Encrypted"
-                      : "Not Encrypted"}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="text-muted-foreground">Raw Content Data:</td>
-                  <td className="pl-16">
-                    {firstTransaction?.encryptedData ? (
-                      <div className="bg-muted/50 rounded-md p-2">
-                        <div className="text-muted-foreground">Encrypted</div>
-                      </div>
-                    ) : (
-                      <div className="bg-muted/50 rounded-md p-2">
-                        <JsonEditor
-                          data={contentData}
-                          restrictEdit={true}
-                          restrictDelete={true}
-                          restrictAdd={true}
-                          restrictDrag={true}
-                          restrictTypeSelection={true}
-                          theme="githubLight"
-                          collapse={true}
-                          rootFontSize={14}
-                        />
-                      </div>
-                    )}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </CardContent>
-          <CardFooter className="flex flex-col border-t bg-muted/50 px-6 py-3 gap-6">
-            <div className="grid grid-cols-1 gap-4 w-full">
-              <div className="grid gap-3">
-                <div className="font-semibold">Actions & Payments</div>
-                <div className="overflow-x-scroll">
-                  <TransactionsAndPaymentsTable
-                    transactions={request?.transactions || []}
-                    payments={requestPayments || []}
-                  />
-                </div>
-              </div>
-            </div>
-            {srfDeployments && srfDeployments.length > 0 && (
-              <div className="w-full">
-                <SRFInfoSection deployments={srfDeployments} />
-              </div>
-            )}
-          </CardFooter>
-        </Card>
-      </div>
-    </div>
-  );
+  return <RequestDetails id={id} request={request} />;
 }

--- a/src/app/request/[id]/request-details.tsx
+++ b/src/app/request/[id]/request-details.tsx
@@ -1,0 +1,451 @@
+/** @format */
+"use client";
+
+import { SRFInfoSection } from "@/components/srf-info-section";
+import { TransactionsAndPaymentsTable } from "@/components/transactions-and-payments-table";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import useExportPDF from "@/lib/hooks/use-export-pdf";
+import { fetchRequestPayments } from "@/lib/queries/request-payments";
+import { fetchProxyDeploymentsByReference } from "@/lib/queries/srf-deployments";
+import type { Channel } from "@/lib/types";
+import {
+  calculateLongPaymentReference,
+  calculateShortPaymentReference,
+  capitalize,
+  commonQueryOptions,
+  formatTimestamp,
+  getAmountWithCurrencySymbol,
+  getBalance,
+  getContentDataFromCreateTransaction,
+  getPaymentDataFromCreateTransaction,
+  getTransactionCreateParameters,
+  renderAddress,
+} from "@/lib/utils";
+import type { ActorInfo } from "@requestnetwork/data-format";
+import { useQuery } from "@tanstack/react-query";
+import { Copy, File, Loader2 } from "lucide-react";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useState } from "react";
+import TimeAgo from "timeago-react";
+
+// json-edit-react's theme provider writes to document.documentElement during
+// render, so it throws under SSR. Loading it client-only keeps the rest of the
+// page server-rendered; the raw JSON blob is not the indexable content anyway.
+const JsonEditor = dynamic(
+  () => import("json-edit-react").then((m) => m.JsonEditor),
+  { ssr: false },
+);
+
+interface RequestDetailsProps {
+  id: string;
+  request: Channel;
+}
+
+const getGateway = (request: Channel | null) => {
+  if (request?.source === "storage_sepolia") {
+    return "sepolia.gateway.request.network";
+  }
+  return "gnosis.gateway.request.network";
+};
+
+const ActorInfoSection = ({
+  actorInfo,
+  isEncrypted,
+}: { actorInfo?: ActorInfo; isEncrypted?: boolean }) => {
+  if (
+    !actorInfo ||
+    Object.keys(actorInfo).every(
+      (k) => !Object.keys((actorInfo as any)[k]).length,
+    )
+  ) {
+    return "N/A";
+  }
+
+  if (isEncrypted) {
+    return (
+      <div className="grid gap-3 bg-muted/50 rounded-md p-2 overflow-x-scroll">
+        <ul className="grid gap-3">
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Status:</span>
+            <span>Encrypted</span>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 bg-muted/50 rounded-md p-2 overflow-x-scroll">
+      <ul className="grid gap-3">
+        {actorInfo?.businessName && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Business Name:</span>
+            <span>{actorInfo?.businessName}</span>
+          </li>
+        )}
+        {actorInfo?.firstName && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">First Name:</span>
+            <span>{actorInfo?.firstName}</span>
+          </li>
+        )}
+        {actorInfo?.lastName && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Last Name:</span>
+            <span>{actorInfo?.lastName}</span>
+          </li>
+        )}
+        {actorInfo?.email && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Email:</span>
+            <span>{actorInfo?.email}</span>
+          </li>
+        )}
+        {actorInfo?.phone && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Phone:</span>
+            <span>{actorInfo?.phone}</span>
+          </li>
+        )}
+        {actorInfo?.address && Object.keys(actorInfo?.address).length > 0 && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Address:</span>
+            <span>{renderAddress(actorInfo)}</span>
+          </li>
+        )}
+        {actorInfo?.taxRegistration && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Tax Registration:</span>
+            <span>{actorInfo?.taxRegistration}</span>
+          </li>
+        )}
+        {actorInfo?.miscellaneous! && (
+          <li className="flex items-center justify-start gap-2">
+            <span className="text-muted-foreground">Miscellaneous:</span>
+            <span>{JSON.stringify(actorInfo?.miscellaneous!)}</span>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export const RequestDetails = ({ id, request }: RequestDetailsProps) => {
+  const { exportPDF } = useExportPDF();
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const shortPaymentReference = calculateShortPaymentReference(
+    id,
+    request?.transactions?.[0]?.dataObject?.data?.parameters
+      ?.extensionsData?.[0]?.parameters.salt || "",
+    request?.transactions?.[0]?.dataObject?.data?.parameters
+      ?.extensionsData?.[0]?.parameters.paymentAddress || "",
+  );
+
+  const longPaymentReference = shortPaymentReference
+    ? calculateLongPaymentReference(shortPaymentReference)
+    : "";
+
+  const { data: requestPayments, isLoading: isLoadingRequestPayments } =
+    useQuery({
+      queryKey: ["request-payments", longPaymentReference],
+      queryFn: () => fetchRequestPayments({ reference: longPaymentReference }),
+      ...commonQueryOptions,
+    });
+
+  const { data: srfDeployments } = useQuery({
+    queryKey: ["srf-deployments", longPaymentReference],
+    queryFn: () =>
+      fetchProxyDeploymentsByReference({ reference: longPaymentReference }),
+    enabled: !!longPaymentReference,
+    ...commonQueryOptions,
+  });
+
+  const firstTransaction = request?.transactions?.[0];
+  const lastTransaction =
+    request?.transactions?.[request.transactions.length - 1];
+
+  const balance = getBalance(requestPayments);
+
+  const createParametersFromFirstTransaction =
+    getTransactionCreateParameters(firstTransaction);
+  const createParametersFromLastTransaction =
+    getTransactionCreateParameters(lastTransaction);
+
+  const contentData = getContentDataFromCreateTransaction(
+    createParametersFromLastTransaction,
+  );
+  const paymentData = getPaymentDataFromCreateTransaction(
+    createParametersFromFirstTransaction,
+  );
+
+  const balanceCurrency =
+    paymentData?.acceptedTokens?.length > 0
+      ? paymentData.acceptedTokens[0]
+      : "";
+
+  const buyerData = contentData?.buyerInfo;
+  const sellerData = contentData?.sellerInfo;
+
+  const status =
+    balance >= BigInt(createParametersFromFirstTransaction?.expectedAmount || 0)
+      ? "Paid"
+      : lastTransaction?.dataObject?.data?.name;
+
+  const modifiedTimestamp =
+    requestPayments &&
+    requestPayments[requestPayments?.length - 1]?.timestamp >
+      lastTransaction?.blockTimestamp
+      ? requestPayments[requestPayments?.length - 1]?.timestamp
+      : lastTransaction?.blockTimestamp;
+
+  const handleExportPDF = async () => {
+    setIsDownloading(true);
+    try {
+      await exportPDF({
+        ...contentData,
+        currency: createParametersFromFirstTransaction?.currency,
+        currencyInfo: createParametersFromFirstTransaction?.currency,
+        payer: createParametersFromFirstTransaction?.payer,
+        payee: createParametersFromFirstTransaction?.payee,
+        expectedAmount: createParametersFromFirstTransaction?.expectedAmount,
+        paymentData,
+      });
+    } catch (error) {
+      console.error("Error exporting PDF:", error);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <div className="h-full pt-24 pb-32">
+      <div className="w-[95%] bg-white border rounded-lg self-center md:w-full">
+        <Card className="overflow-hidden" x-chunk="dashboard-05-chunk-4">
+          <CardHeader className="flex flex-row items-start bg-muted/50">
+            <div className="grid gap-0.5 w-full">
+              <CardTitle className="group flex items-center gap-2 text-lg break-all w-full justify-between">
+                <div className="flex gap-2 items-center">
+                  Request {id}
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    className="h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={() => {
+                      navigator.clipboard.writeText(id);
+                    }}
+                  >
+                    <Copy className="h-3 w-3" />
+                  </Button>
+                </div>
+                <Button
+                  size="sm"
+                  className="h-8 gap-1"
+                  onClick={handleExportPDF}
+                  disabled={isDownloading}
+                >
+                  {isDownloading && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  <File className="h-3.5 w-3.5" />
+                  <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
+                    Export PDF
+                  </span>
+                </Button>
+              </CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="p-6 text-sm overflow-x-scroll">
+            <table className="border-separate border-spacing-y-3">
+              <tbody>
+                <tr>
+                  <td className="text-muted-foreground">Status:</td>
+                  <td className="pl-16">
+                    {isLoadingRequestPayments ? (
+                      <Skeleton className="h-4 w-24" />
+                    ) : (
+                      status
+                    )}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Gateway:</td>
+                  <td className="pl-16">{getGateway(request)}</td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Payee:</td>
+                  <td className="pl-16">
+                    <div className="font-medium text-emerald-700 break-all">
+                      <Link
+                        href={`/address/${createParametersFromFirstTransaction?.payee?.value}`}
+                      >
+                        {createParametersFromFirstTransaction?.payee?.value}
+                      </Link>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Payee Details:</td>
+                  <td className="pl-16">
+                    <ActorInfoSection
+                      actorInfo={sellerData}
+                      isEncrypted={!!firstTransaction?.encryptedData}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Payer:</td>
+                  <td className="pl-16">
+                    <div className="font-medium text-emerald-700 break-all">
+                      <Link
+                        href={`/address/${createParametersFromFirstTransaction?.payer?.value}`}
+                      >
+                        {createParametersFromFirstTransaction?.payer?.value}
+                      </Link>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Payer Details:</td>
+                  <td className="pl-16">
+                    <ActorInfoSection
+                      actorInfo={buyerData}
+                      isEncrypted={!!firstTransaction?.encryptedData}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Expected Amount:</td>
+                  <td className="pl-16">
+                    {getAmountWithCurrencySymbol(
+                      BigInt(
+                        createParametersFromFirstTransaction?.expectedAmount ||
+                          0,
+                      ),
+                      createParametersFromFirstTransaction?.currency?.value ||
+                        "",
+                    )}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Balance:</td>
+                  <td className="pl-16">
+                    {isLoadingRequestPayments ? (
+                      <Skeleton className="h-4 w-24" />
+                    ) : (
+                      getAmountWithCurrencySymbol(
+                        BigInt(balance),
+                        balanceCurrency || "",
+                      )
+                    )}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Created:</td>
+                  <td className="pl-16">
+                    <TimeAgo
+                      datetime={(firstTransaction?.blockTimestamp || 0) * 1000}
+                      locale="en_short"
+                    />{" "}
+                    ({formatTimestamp(firstTransaction?.blockTimestamp || 0)})
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Modified:</td>
+                  <td className="pl-16">
+                    {isLoadingRequestPayments ? (
+                      <Skeleton className="h-4 w-24" />
+                    ) : (
+                      <>
+                        <TimeAgo
+                          datetime={modifiedTimestamp * 1000}
+                          locale="en_short"
+                        />{" "}
+                        ({formatTimestamp(modifiedTimestamp)})
+                      </>
+                    )}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Payment Reference:</td>
+                  <td className="pl-16">{shortPaymentReference}</td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Blockchain:</td>
+                  <td className="pl-16">
+                    {paymentData?.network
+                      ? capitalize(paymentData?.network)
+                      : ""}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Encryption Status:</td>
+                  <td className="pl-16">
+                    {firstTransaction?.encryptedData
+                      ? "Encrypted"
+                      : "Not Encrypted"}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="text-muted-foreground">Raw Content Data:</td>
+                  <td className="pl-16">
+                    {firstTransaction?.encryptedData ? (
+                      <div className="bg-muted/50 rounded-md p-2">
+                        <div className="text-muted-foreground">Encrypted</div>
+                      </div>
+                    ) : (
+                      <div className="bg-muted/50 rounded-md p-2">
+                        <JsonEditor
+                          data={contentData}
+                          restrictEdit={true}
+                          restrictDelete={true}
+                          restrictAdd={true}
+                          restrictDrag={true}
+                          restrictTypeSelection={true}
+                          theme="githubLight"
+                          collapse={true}
+                          rootFontSize={14}
+                        />
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </CardContent>
+          <CardFooter className="flex flex-col border-t bg-muted/50 px-6 py-3 gap-6">
+            <div className="grid grid-cols-1 gap-4 w-full">
+              <div className="grid gap-3">
+                <div className="font-semibold">Actions & Payments</div>
+                <div className="overflow-x-scroll">
+                  {isLoadingRequestPayments ? (
+                    <Skeleton className="h-[200px] w-full rounded-xl" />
+                  ) : (
+                    <TransactionsAndPaymentsTable
+                      transactions={request?.transactions || []}
+                      payments={requestPayments || []}
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+            {srfDeployments && srfDeployments.length > 0 && (
+              <div className="w-full">
+                <SRFInfoSection deployments={srfDeployments} />
+              </div>
+            )}
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Makes the request page serve the actual request in its HTML, instead of an empty skeleton. Top of the stack, on #117.

#116 stopped the 500s, but the page still served nothing useful: it fetched on the client, so the HTML was a skeleton with **zero** request data. For the SEO audit that started this, a 200 with an empty shell is barely better than the 500 it replaced.

`page.tsx` is now an async server component that awaits `fetchRequest` and passes the `Channel` to a new client component, `request-details.tsx`, which keeps everything genuinely browser-bound: PDF export, the JSON viewer, clipboard buttons, `TimeAgo`, `useState`. The relocation is verbatim — same markup, classNames, copy, table structure.

**Verified** against a local stand-in backend: the served HTML now contains the gateway, payee, payer, expected amount, payment reference, encryption status, and the transactions table. Before, none of it was there.

Plus `generateMetadata`, so these pages finally have a real title and description for search results and link previews.

## Two findings worth reading

### json-edit-react cannot be server-rendered

Its theme provider calls `document.documentElement.style.setProperty("--jer-highlight-color", …)` **during render**. The moment the details actually server-rendered, that threw `ReferenceError: document is not defined`, React bailed out to client rendering, and the HTML went straight back to being an empty shell — the twin of #116's bug, hidden until now because SSR had never got as far as rendering this component.

It is now loaded via `next/dynamic` with `ssr: false`. The raw JSON blob is not the indexable content, so nothing is lost.

Note this is a *render-time* touch of `document`, not an import-time one — which is why an import-level audit of the very same file came back clean. Worth remembering when auditing the next one.

### A missing request still returns 200, not 404

It renders the not-found UI, but the status is wrong, and this is a framework limit rather than something left undone.

The route streams (`Transfer-Encoding: chunked`), so the HTTP status commits when the shell flushes — before the lookup resolves. `notFound()` can then only swap the rendered UI. Both placements were tried and measured:

| Approach | Result |
| --- | --- |
| `notFound()` from the page body | 200 |
| `notFound()` from `generateMetadata` | 200 |

A real 404 needs the existence check to run before the response commits — i.e. middleware, with a Hasura call on every request. That is a bigger trade than this PR should make unilaterally, so I stopped and flagged it instead.

**What I did instead addresses the actual harm:** a missing request is served `<meta name="robots" content="noindex, nofollow">`, which is what stops soft 404s accumulating in the search index. Valid requests are not noindexed — checked both ways.

## Implementation notes

- The request lookup is wrapped in React's `cache()` keyed on the id, so `generateMetadata` and the page share **one** network call. The fetch-level cache cannot do this: `graphql-request` issues a POST, which Next's Data Cache does not dedupe, and the `cache()` inside `graphQlClient` is keyed on a fresh `RequestInit` per call.
- A thrown fetch is deliberately left to propagate to the error boundary. A backend outage must not be reported as "this request does not exist" — that distinction was established in #116 and is preserved here.
- The two dependent queries (payments, SRF deployments) stay client-side: they hang off a payment reference derived from the request, they are the polling surface via `refetchInterval`, and keeping them there guarantees neither can affect the HTTP status or block the request's own content.
- **One deliberate behaviour change:** the page no longer blocks on a full-page skeleton while payments load. The four payments-derived cells — Status, Balance, Modified, and the payments table — render their own inline loading state. Without that they would briefly display *wrong* values (`Balance: 0`, Status taken from the last transaction instead of "Paid") before the query lands. Everything else renders immediately from the server.

## Verification

`npm run check` ✅, `npm run build` ✅, `tsc --noEmit` clean, zero SSR errors in the server log, and against a local stand-in backend:

| Check | Result |
| --- | --- |
| Request fields in served HTML | ✅ present (were absent) |
| Missing request → `noindex` | ✅ |
| Valid request → not noindexed | ✅ |
| Missing request → 404 status | ❌ 200 — framework limit, documented above |
