### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "request-scan",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "request-scan",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@next/third-parties": "^15.0.3",
         "@radix-ui/react-avatar": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "request-scan",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Bumps the version `0.3.4` → `0.4.0` and regenerates the lockfile.

Covers the three fixes just merged:

- **#116** — every `/request/<id>` URL returned HTTP 500 (`html2pdf.js` evaluating a bare `self` at import time under Node)
- **#117** — one unavailable subgraph wiped out all payment data; queries are now per-chain, plus the repo's first tests
- **#118** — the request page is server-rendered, so crawlers and link previews receive the request instead of an empty skeleton

Minor rather than patch, since #118 changes how that route renders and #117 changes the query layer's failure behaviour.

## Notes

- **The lockfile diff is only the two version fields** — no dependency was upgraded as a side effect. Worth stating, since running `npm install` on a bump can quietly pull newer versions within existing ranges.
- The footer version badge reads `version` from `package.json` (`src/components/ui/version-badge.tsx`), so it picks this up with no code change — it will read `0.4.0` once deployed.

## Verification

`npm run check` ✅ · `npm test` 5/5 ✅ · `npx tsc --noEmit` ✅ · `npm run build` ✅

## Heads-up on production

Production is still serving the 500 on `/request/<id>`. Staging auto-deployed on merge and is verified returning 200, but production deploys only on a **published release** — so the three merged fixes are not live on `scan.request.network` yet. This bump is presumably the version you'd cut that release at; the release itself is a human action and I have not taken it.
